### PR TITLE
docs: updates `brew` command to use new cask syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ But overall it's a much more comfortable experience to connect to the Bastion
 Session Manager Plugin. On Mac OSX you can get it via homebrew for example:
 
 ```
-brew cask install session-manager-plugin
+brew install --cask session-manager-plugin
 ```
 
 For Linux it should also be available in the respective package manager. Also


### PR DESCRIPTION
`brew cask` is deprecated and no longer works.

```
$> brew cask install session-manager-plugin
Error: Unknown command: cask
```