### PR TITLE
Expose bastionHost and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ export class BastionHostPocStack extends cdk.Stack {
     super(scope, id, props);
 
     const vpc = Vpc.fromLookup(this, 'MyVpc', {
-      vpcId: 'vpc-0123456789abcd'
+      vpcId: 'vpc-0123456789abcd',
     });
 
     const securityGroup = SecurityGroup.fromSecurityGroupId(
       this,
       'RDSSecurityGroup',
       'odsufa5addasdj',
-      { mutable: false }
+      { mutable: false },
     );
 
     const rdsInstance = DatabaseInstance.fromDatabaseInstanceAttributes(
@@ -133,10 +133,11 @@ export class BastionHostPocStack extends cdk.Stack {
       'MyDb',
       {
         instanceIdentifier: 'abcd1234geh',
-        instanceEndpointAddress: 'abcd1234geh.ughia8asd.eu-central-1.rds.amazonaws.com',
+        instanceEndpointAddress:
+          'abcd1234geh.ughia8asd.eu-central-1.rds.amazonaws.com',
         port: 5432,
-        securityGroups: [securityGroup]
-      }
+        securityGroups: [securityGroup],
+      },
     );
 
     const bastion = new BastionHostRDSForward(this, 'BastionHost', {
@@ -217,13 +218,17 @@ export class PocRedshiftStack extends cdk.Stack {
       },
     );
 
-    const bastion = new GenericBastionHostForward(this, 'BastionHostRedshiftForward', {
-      vpc,
-      securityGroup,
-      name: 'MyRedshiftBastionHost',
-      address: redshiftCluster.clusterEndpointAddress,
-      port: redshiftCluster.clusterEndpointPort,
-    });
+    const bastion = new GenericBastionHostForward(
+      this,
+      'BastionHostRedshiftForward',
+      {
+        vpc,
+        securityGroup,
+        name: 'MyRedshiftBastionHost',
+        address: redshiftCluster.clusterEndpointAddress,
+        port: redshiftCluster.clusterEndpointPort,
+      },
+    );
 
     bastion.bastionHost.instance.connections.allowToDefaultPort(
       redshiftCluster,
@@ -342,14 +347,14 @@ export class BastionHostPocStack extends cdk.Stack {
     super(scope, id, props);
 
     const vpc = Vpc.fromLookup(this, 'MyVpc', {
-      vpcId: 'vpc-0123456789abcd'
+      vpcId: 'vpc-0123456789abcd',
     });
 
     const securityGroup = SecurityGroup.fromSecurityGroupId(
       this,
       'AuroraSecurityGroup',
       'odsufa5addasdj',
-      { mutable: false }
+      { mutable: false },
     );
 
     const serverlessCluster = ServerlessCluster.fromServerlessClusterAttributes(
@@ -358,15 +363,20 @@ export class BastionHostPocStack extends cdk.Stack {
       {
         clusterIdentifier: 'my-cluster',
         port: 3306,
-        clusterEndpointAddress: 'my-aurora.cluster-abcdef.eu-central-1.rds.amazonaws.com',
-        securityGroups: [securityGroup]
-      }
+        clusterEndpointAddress:
+          'my-aurora.cluster-abcdef.eu-central-1.rds.amazonaws.com',
+        securityGroups: [securityGroup],
+      },
     );
 
-    const bastion = new BastionHostAuroraServerlessForward(this, 'BastionHost', {
-      vpc,
-      serverlessCluster,
-    });
+    const bastion = new BastionHostAuroraServerlessForward(
+      this,
+      'BastionHost',
+      {
+        vpc,
+        serverlessCluster,
+      },
+    );
 
     bastion.bastionHost.instance.connections.allowToDefaultPort(
       serverlessCluster,

--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ export class BastionHostPocStack extends cdk.Stack {
     super(scope, id, props);
 
     const vpc = Vpc.fromLookup(this, 'MyVpc', {
-      vpcId: 'vpc-0123456789abcd',
+      vpcId: 'vpc-0123456789abcd'
     });
 
     const securityGroup = SecurityGroup.fromSecurityGroupId(
       this,
       'RDSSecurityGroup',
       'odsufa5addasdj',
-      { mutable: false },
+      { mutable: false }
     );
 
     const rdsInstance = DatabaseInstance.fromDatabaseInstanceAttributes(
@@ -133,10 +133,9 @@ export class BastionHostPocStack extends cdk.Stack {
       'MyDb',
       {
         instanceIdentifier: 'abcd1234geh',
-        instanceEndpointAddress:
-          'abcd1234geh.ughia8asd.eu-central-1.rds.amazonaws.com',
+        instanceEndpointAddress: 'abcd1234geh.ughia8asd.eu-central-1.rds.amazonaws.com',
         port: 5432,
-        securityGroups: [securityGroup],
+        securityGroups: [securityGroup]
       },
     );
 
@@ -218,17 +217,13 @@ export class PocRedshiftStack extends cdk.Stack {
       },
     );
 
-    const bastion = new GenericBastionHostForward(
-      this,
-      'BastionHostRedshiftForward',
-      {
-        vpc,
-        securityGroup,
-        name: 'MyRedshiftBastionHost',
-        address: redshiftCluster.clusterEndpointAddress,
-        port: redshiftCluster.clusterEndpointPort,
-      },
-    );
+    const bastion = new GenericBastionHostForward(this, 'BastionHostRedshiftForward', {
+      vpc,
+      securityGroup,
+      name: 'MyRedshiftBastionHost',
+      address: redshiftCluster.clusterEndpointAddress,
+      port: redshiftCluster.clusterEndpointPort,
+    });
 
     bastion.bastionHost.instance.connections.allowToDefaultPort(
       redshiftCluster,
@@ -347,14 +342,14 @@ export class BastionHostPocStack extends cdk.Stack {
     super(scope, id, props);
 
     const vpc = Vpc.fromLookup(this, 'MyVpc', {
-      vpcId: 'vpc-0123456789abcd',
+      vpcId: 'vpc-0123456789abcd'
     });
 
     const securityGroup = SecurityGroup.fromSecurityGroupId(
       this,
       'AuroraSecurityGroup',
       'odsufa5addasdj',
-      { mutable: false },
+      { mutable: false }
     );
 
     const serverlessCluster = ServerlessCluster.fromServerlessClusterAttributes(
@@ -363,20 +358,15 @@ export class BastionHostPocStack extends cdk.Stack {
       {
         clusterIdentifier: 'my-cluster',
         port: 3306,
-        clusterEndpointAddress:
-          'my-aurora.cluster-abcdef.eu-central-1.rds.amazonaws.com',
-        securityGroups: [securityGroup],
+        clusterEndpointAddress: 'my-aurora.cluster-abcdef.eu-central-1.rds.amazonaws.com',
+        securityGroups: [securityGroup]
       },
     );
 
-    const bastion = new BastionHostAuroraServerlessForward(
-      this,
-      'BastionHost',
-      {
-        vpc,
-        serverlessCluster,
-      },
-    );
+    const bastion = new BastionHostAuroraServerlessForward(this, 'BastionHost', {
+      vpc,
+      serverlessCluster,
+    });
 
     bastion.bastionHost.instance.connections.allowToDefaultPort(
       serverlessCluster,

--- a/README.md
+++ b/README.md
@@ -139,11 +139,15 @@ export class BastionHostPocStack extends cdk.Stack {
       }
     );
 
-    new BastionHostRDSForward(this, 'BastionHost', {
+    const bastion = new BastionHostRDSForward(this, 'BastionHost', {
       vpc: vpc,
       rdsInstance: rdsInstance,
       name: 'MyBastionHost',
     });
+
+    bastion.bastionHost.instance.connections.allowToDefaultPort(rdsInstance);
+  }
+}
 ```
 
 If the RDS is IAM Authenticated you also need to add an `iam_user` and
@@ -175,6 +179,9 @@ connection to a RedShift instance, but this can also be a Redis Node or any
 other data store on AWS. Instead of passing the complete L2 construct and
 letting the library extract the necessary properties, the client is passing them
 directly to the construct:
+
+__Note:__ This example is outdated now that a Redshift L2 construct is not longer
+available, but it illustrates the required steps.
 
 ```typescript
 import * as cdk from '@aws-cdk/core';
@@ -210,13 +217,15 @@ export class PocRedshiftStack extends cdk.Stack {
       },
     );
 
-    new GenericBastionHostForward(this, 'BastionHostRedshiftForward', {
+    const bastion = new GenericBastionHostForward(this, 'BastionHostRedshiftForward', {
       vpc,
       securityGroup,
       name: 'MyRedshiftBastionHost',
       address: redshiftCluster.clusterEndpointAddress,
       port: redshiftCluster.clusterEndpointPort,
     });
+
+    bastion.bastionHost.instance.connections.allowToDefaultPort(redshiftCluster);
   }
 }
 ```
@@ -251,15 +260,17 @@ class PocRedshiftStack(cdk.Stack):
             cluster_endpoint_port=5439
         )
 
-        bastion_host_forward.GenericBastionHostForward(
+        bastion = bastion_host_forward.GenericBastionHostForward(
             self,
             "bastion-host",
             name="my-bastion-host",
             security_group=security_group,
-            address: redshift_cluster.cluster_endpoint_address,
+            address=redshift_cluster.cluster_endpoint_address,
             port: redshift_cluster.cluster_endpoint_port,
             vpc=vpc
         )
+
+        bastion.bastion_host.instance.connections.allow_to_default_port(redshift_cluster)
 ```
 
 ## Bastion Host for Multiple Endpoints
@@ -287,7 +298,7 @@ export class PocMultiDBStack extends Stack {
       instanceIdentifier: 'efgh5678ijk',
     });
 
-    new MultiendpointBastionHostForward(this, 'Bastion', {
+    const bastion = new MultiendpointBastionHostForward(this, 'Bastion', {
       vpc,
       clientTimeout: 30,
       serverTimeout: 30,
@@ -305,6 +316,9 @@ export class PocMultiDBStack extends Stack {
         },
       ],
     });
+
+    bastion.bastionHost.instance.connections.allowToDefaultPort(primary);
+    bastion.bastionHost.instance.connections.allowToDefaultPort(replica);
   }
 }
 ```
@@ -347,10 +361,14 @@ export class BastionHostPocStack extends cdk.Stack {
       }
     );
 
-    new BastionHostAuroraServerlessForward(this, 'BastionHost', {
+    const bastion = new BastionHostAuroraServerlessForward(this, 'BastionHost', {
       vpc,
       serverlessCluster,
     });
+
+    bastion.bastionHost.instance.connections.allowToDefaultPort(serverlessCluster);
+  }
+}
 ```
 
 ## Deploying the Bastion Host

--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ export class BastionHostPocStack extends cdk.Stack {
     super(scope, id, props);
 
     const vpc = Vpc.fromLookup(this, 'MyVpc', {
-      vpcId: 'vpc-0123456789abcd'
+      vpcId: 'vpc-0123456789abcd',
     });
 
     const securityGroup = SecurityGroup.fromSecurityGroupId(
       this,
       'RDSSecurityGroup',
       'odsufa5addasdj',
-      { mutable: false }
+      { mutable: false },
     );
 
     const rdsInstance = DatabaseInstance.fromDatabaseInstanceAttributes(
@@ -133,10 +133,11 @@ export class BastionHostPocStack extends cdk.Stack {
       'MyDb',
       {
         instanceIdentifier: 'abcd1234geh',
-        instanceEndpointAddress: 'abcd1234geh.ughia8asd.eu-central-1.rds.amazonaws.com',
+        instanceEndpointAddress:
+          'abcd1234geh.ughia8asd.eu-central-1.rds.amazonaws.com',
         port: 5432,
-        securityGroups: [securityGroup]
-      }
+        securityGroups: [securityGroup],
+      },
     );
 
     const bastion = new BastionHostRDSForward(this, 'BastionHost', {
@@ -180,7 +181,7 @@ other data store on AWS. Instead of passing the complete L2 construct and
 letting the library extract the necessary properties, the client is passing them
 directly to the construct:
 
-__Note:__ This example is outdated now that a Redshift L2 construct is not longer
+**Note:** This example is outdated now that a Redshift L2 construct is not longer
 available, but it illustrates the required steps.
 
 ```typescript
@@ -217,15 +218,21 @@ export class PocRedshiftStack extends cdk.Stack {
       },
     );
 
-    const bastion = new GenericBastionHostForward(this, 'BastionHostRedshiftForward', {
-      vpc,
-      securityGroup,
-      name: 'MyRedshiftBastionHost',
-      address: redshiftCluster.clusterEndpointAddress,
-      port: redshiftCluster.clusterEndpointPort,
-    });
+    const bastion = new GenericBastionHostForward(
+      this,
+      'BastionHostRedshiftForward',
+      {
+        vpc,
+        securityGroup,
+        name: 'MyRedshiftBastionHost',
+        address: redshiftCluster.clusterEndpointAddress,
+        port: redshiftCluster.clusterEndpointPort,
+      },
+    );
 
-    bastion.bastionHost.instance.connections.allowToDefaultPort(redshiftCluster);
+    bastion.bastionHost.instance.connections.allowToDefaultPort(
+      redshiftCluster,
+    );
   }
 }
 ```
@@ -340,14 +347,14 @@ export class BastionHostPocStack extends cdk.Stack {
     super(scope, id, props);
 
     const vpc = Vpc.fromLookup(this, 'MyVpc', {
-      vpcId: 'vpc-0123456789abcd'
+      vpcId: 'vpc-0123456789abcd',
     });
 
     const securityGroup = SecurityGroup.fromSecurityGroupId(
       this,
       'AuroraSecurityGroup',
       'odsufa5addasdj',
-      { mutable: false }
+      { mutable: false },
     );
 
     const serverlessCluster = ServerlessCluster.fromServerlessClusterAttributes(
@@ -356,17 +363,24 @@ export class BastionHostPocStack extends cdk.Stack {
       {
         clusterIdentifier: 'my-cluster',
         port: 3306,
-        clusterEndpointAddress: 'my-aurora.cluster-abcdef.eu-central-1.rds.amazonaws.com',
-        securityGroups: [securityGroup]
-      }
+        clusterEndpointAddress:
+          'my-aurora.cluster-abcdef.eu-central-1.rds.amazonaws.com',
+        securityGroups: [securityGroup],
+      },
     );
 
-    const bastion = new BastionHostAuroraServerlessForward(this, 'BastionHost', {
-      vpc,
-      serverlessCluster,
-    });
+    const bastion = new BastionHostAuroraServerlessForward(
+      this,
+      'BastionHost',
+      {
+        vpc,
+        serverlessCluster,
+      },
+    );
 
-    bastion.bastionHost.instance.connections.allowToDefaultPort(serverlessCluster);
+    bastion.bastionHost.instance.connections.allowToDefaultPort(
+      serverlessCluster,
+    );
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ other data store on AWS. Instead of passing the complete L2 construct and
 letting the library extract the necessary properties, the client is passing them
 directly to the construct:
 
-**Note:** This example is outdated now that a Redshift L2 construct is not longer
+**Note:** This example is outdated now that a Redshift L2 construct is no longer
 available, but it illustrates the required steps.
 
 ```typescript
@@ -273,7 +273,7 @@ class PocRedshiftStack(cdk.Stack):
             name="my-bastion-host",
             security_group=security_group,
             address=redshift_cluster.cluster_endpoint_address,
-            port: redshift_cluster.cluster_endpoint_port,
+            port=redshift_cluster.cluster_endpoint_port,
             vpc=vpc
         )
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ export class BastionHostPocStack extends cdk.Stack {
         instanceEndpointAddress: 'abcd1234geh.ughia8asd.eu-central-1.rds.amazonaws.com',
         port: 5432,
         securityGroups: [securityGroup]
-      },
+      }
     );
 
     const bastion = new BastionHostRDSForward(this, 'BastionHost', {
@@ -360,7 +360,7 @@ export class BastionHostPocStack extends cdk.Stack {
         port: 3306,
         clusterEndpointAddress: 'my-aurora.cluster-abcdef.eu-central-1.rds.amazonaws.com',
         securityGroups: [securityGroup]
-      },
+      }
     );
 
     const bastion = new BastionHostAuroraServerlessForward(this, 'BastionHost', {

--- a/README.md
+++ b/README.md
@@ -200,16 +200,12 @@ export class PocRedshiftStack extends cdk.Stack {
         mutable: false,
       },
     );
-    const redshiftCluster = new CfnCluster(
-      this,
-      'RedshiftCluster',
-      {
-        dbName: 'myRedshiftClusterName',
-        masterUsername: 'test',
-        nodeType: 'dc2.large',
-        clusterType: 'single-node',
-      },
-    );
+    const redshiftCluster = new CfnCluster(this, 'RedshiftCluster', {
+      dbName: 'myRedshiftClusterName',
+      masterUsername: 'test',
+      nodeType: 'dc2.large',
+      clusterType: 'single-node',
+    });
 
     new GenericBastionHostForward(this, 'BastionHostRedshiftForward', {
       vpc,

--- a/lib/bastion-host-forward.ts
+++ b/lib/bastion-host-forward.ts
@@ -111,7 +111,7 @@ export class BastionHostForward extends Construct {
   /**
    * @returns The BastionHost Instance
    */
-  protected readonly bastionHost: BastionHostLinux;
+  public readonly bastionHost: BastionHostLinux;
 
   protected constructor(
     scope: Construct,


### PR DESCRIPTION
Exposes the underlying bastionHost to make it easier to manage connection permissions. Its possible I'm missing something or that there is an easier way of accomplishing this. But I've previously had to extend these classes in my own codebase to get access to this instance variable. And I would imagine others would have run into the same problem. 

Arguably the BastionHostForward construct should take care of setting up the connection. But I've run into enough issues with managing these connections in the past, especially cross stack, that it may still be better to leave that responsibility to the end user.

I've also updated the documentation to indicate how to use this. But I haven't tested those examples specifically so I can't guarantee they're exactly correct. I believe the Redshift example is also out of date in other ways, so added a comment explaining that. Unfortunately I don't have the bandwidth to actually fix that example.