### PR TITLE
feat: use t4g.micro by default when patch management is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Currently the following AWS Services are supported:
 
 With version 3 a patch manager component is included so that the bastion host instance is provided with security updates on a regular basis. These happen in a maintenance window every sunday at 3am (timezone where it's deployed). To disable the patching, you need to provide the attribute `shouldPatch: false`.
 
+When patching is enabled (the default), the default instance type is automatically set to `t4g.micro` instead of `t4g.nano` to prevent OOM kills during the patch maintenance window. If you set `instanceType` explicitly, that value is always used regardless of the `shouldPatch` setting.
+
 Example:
 
 ```typescript

--- a/lib/bastion-host-forward-base-props.ts
+++ b/lib/bastion-host-forward-base-props.ts
@@ -51,6 +51,12 @@ export interface BastionHostForwardBaseProps {
   /**
    * Whether patching should be enabled for the bastion-host-forward instance
    *
+   * When enabled, an SSM Maintenance Window is created to run
+   * `AWS-RunPatchBaseline` every Sunday at 3 AM. To avoid OOM kills during
+   * patching, the default instance size is automatically upgraded from
+   * `t4g.nano` to `t4g.micro` when patching is enabled (unless `instanceType`
+   * is set explicitly).
+   *
    * @default true
    */
   readonly shouldPatch?: boolean;
@@ -78,7 +84,13 @@ export interface BastionHostForwardBaseProps {
 
   /**
    * Type of instance to launch
-   * @default 't4g.nano'
+   *
+   * When not set, the instance size is chosen automatically based on whether
+   * patching is enabled: `t4g.micro` when patching is on (the default), or
+   * `t4g.nano` when patching is disabled. The larger size prevents OOM kills
+   * during the patch maintenance window.
+   *
+   * @default 't4g.micro' when shouldPatch is true (default), 't4g.nano' otherwise
    */
   readonly instanceType?: InstanceType;
 }

--- a/lib/bastion-host-forward.ts
+++ b/lib/bastion-host-forward.ts
@@ -151,6 +151,7 @@ export class BastionHostForward extends Construct {
         allowAllOutbound: true,
       });
 
+    const shouldPatch = props.shouldPatch === undefined || props.shouldPatch;
     const instanceName = props.name ?? 'BastionHost';
     this.bastionHost = new BastionHostLinux(this, 'BastionHost', {
       requireImdsv2: true,
@@ -162,7 +163,10 @@ export class BastionHostForward extends Construct {
       }),
       instanceType:
         props.instanceType ??
-        InstanceType.of(InstanceClass.T4G, InstanceSize.NANO),
+        InstanceType.of(
+          InstanceClass.T4G,
+          shouldPatch ? InstanceSize.MICRO : InstanceSize.NANO,
+        ),
       blockDevices: [
         {
           deviceName: '/dev/xvda',
@@ -188,7 +192,7 @@ export class BastionHostForward extends Construct {
     );
     cfnBastionHost.userData = Fn.base64(shellCommands.render());
 
-    if (props.shouldPatch === undefined || props.shouldPatch) {
+    if (shouldPatch) {
       this.bastionHost.instance.role.addManagedPolicy(
         ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'),
       );

--- a/test/generic-bastion-host-forward.test.ts
+++ b/test/generic-bastion-host-forward.test.ts
@@ -14,7 +14,13 @@
 import { Template } from 'aws-cdk-lib/assertions';
 import { App, Stack } from 'aws-cdk-lib';
 import { strict as assert } from 'assert';
-import { SecurityGroup, Vpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  SecurityGroup,
+  Vpc,
+} from 'aws-cdk-lib/aws-ec2';
 import { GenericBastionHostForward } from '../lib/generic-bastion-host-forward';
 
 test('Bastion Host created for normal access', () => {
@@ -134,6 +140,68 @@ test('Bastion Host has encrypted EBS', () => {
         },
       },
     ],
+  });
+});
+
+test('Bastion Host default instance type is t4g.micro when patching is enabled', () => {
+  const app = new App();
+  const stack = new Stack(app, 'TestStack');
+  const testVpc = new Vpc(stack, 'TestVpc');
+
+  // WHEN — shouldPatch defaults to true
+  new GenericBastionHostForward(stack, 'MyTestConstruct', {
+    vpc: testVpc,
+    address: '127.0.0.1',
+    port: '6379',
+  });
+
+  const template = Template.fromStack(stack);
+
+  // THEN
+  template.hasResourceProperties('AWS::EC2::Instance', {
+    InstanceType: 't4g.micro',
+  });
+});
+
+test('Bastion Host default instance type is t4g.nano when patching is disabled', () => {
+  const app = new App();
+  const stack = new Stack(app, 'TestStack');
+  const testVpc = new Vpc(stack, 'TestVpc');
+
+  // WHEN
+  new GenericBastionHostForward(stack, 'MyTestConstruct', {
+    vpc: testVpc,
+    address: '127.0.0.1',
+    port: '6379',
+    shouldPatch: false,
+  });
+
+  const template = Template.fromStack(stack);
+
+  // THEN
+  template.hasResourceProperties('AWS::EC2::Instance', {
+    InstanceType: 't4g.nano',
+  });
+});
+
+test('Bastion Host explicit instanceType is used regardless of shouldPatch', () => {
+  const app = new App();
+  const stack = new Stack(app, 'TestStack');
+  const testVpc = new Vpc(stack, 'TestVpc');
+
+  // WHEN — explicit instanceType with patching on
+  new GenericBastionHostForward(stack, 'MyTestConstruct', {
+    vpc: testVpc,
+    address: '127.0.0.1',
+    port: '6379',
+    instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+  });
+
+  const template = Template.fromStack(stack);
+
+  // THEN — the explicit value wins, not the patch-bumped default
+  template.hasResourceProperties('AWS::EC2::Instance', {
+    InstanceType: 't4g.small',
   });
 });
 


### PR DESCRIPTION
When `shouldPatch` is true (the default), the bastion host now uses `t4g.micro` instead of `t4g.nano` as the default instance type. This prevents OOM kills observed during the SSM patch maintenance window that runs at 3 AM every Sunday.

If `instanceType` is set explicitly, that value is always used regardless of the `shouldPatch` setting.

**Tests added:**
- Default instance type is `t4g.micro` when patching is enabled
- Default instance type is `t4g.nano` when patching is disabled
- Explicit `instanceType` is always respected regardless of `shouldPatch`

---

Co-authored-by: Claude Sonnet 4.6 via moia-ai-gateway <claude@anthropic.com>